### PR TITLE
fix: inlines could be dragged outside the table

### DIFF
--- a/pops/static/pops/js/pops.inlineFormSet.js
+++ b/pops/static/pops/js/pops.inlineFormSet.js
@@ -184,6 +184,7 @@ if (typeof pops.inlineFormSet === 'undefined') {
       tolerance: 'pointer',
       axis: 'y',
       cancel: 'input,button,select,a,textarea',
+      containment: 'tbody',
       helper: 'clone',
       update: updatePositions
     });


### PR DESCRIPTION
Doesn't fix the jumping width (I found another fix for that but it was going to take way too much work to do it right so I didn't pursue it). Makes the interaction a little better IMO when you can't drag the rows out of the table.
