### PR TITLE
Fix missing object tools block in pops

### DIFF
--- a/pops/templates/admin/base.html
+++ b/pops/templates/admin/base.html
@@ -221,7 +221,6 @@ $(function(){
       <div id="content" class="{% block coltype %}container-fluid{% endblock %}">
           {% block pretitle %}{% endblock %}
           {% block content_title %}{% endblock %}
-          {% block object-tools %}{% endblock %}
           {% block content %}
           {{ content }}
           {% endblock %}

--- a/pops/templates/admin/change_form.html
+++ b/pops/templates/admin/change_form.html
@@ -35,8 +35,17 @@
   {% endif %}
 {% endblock %}
 
-{% block content %}
-<div id="content-main">
+{% block content %}<div id="content-main">
+{% block object-tools %}
+{% if change %}{% if not is_popup %}
+  <ul class="object-tools">
+    {% block object-tools-items %}
+    <li><a href="history/" class="historylink">{% trans "History" %}</a></li>
+    {% if has_absolute_url %}<li><a href="../../../r/{{ content_type_id }}/{{ object_id }}/" class="viewsitelink">{% trans "View on site" %}</a></li>{% endif%}
+    {% endblock %}
+  </ul>
+{% endif %}{% endif %}
+{% endblock %}
   <form {% if has_file_field %}enctype="multipart/form-data"{% endif %}
       action="{{ form_url }}" method="post"
       id="{{ opts.module_name }}_form" class="form-horizontal">

--- a/pops/templates/admin/change_form.html
+++ b/pops/templates/admin/change_form.html
@@ -14,14 +14,14 @@
 
 {% block bodyclass %}{{ opts.app_label }}-{{ opts.object_name.lower }} change-form{% endblock %}
 
-{% block breadcrumbs %}
 {% if not is_popup %}
+{% block breadcrumbs %}
 ../../../|{% trans "Home" %}
 ../../|{{ app_label|capfirst|escape }}
 *{% if has_change_permission %}../|{{ opts.verbose_name_plural|capfirst }}{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
 *{% if add %}{% trans "Add" %} {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}
-{% endif %}
 {% endblock %}
+{% endif %}
 
 {% block content_title %}{% endblock %}
 

--- a/pops/templates/admin/change_list.html
+++ b/pops/templates/admin/change_list.html
@@ -64,6 +64,23 @@ $(function() {
 
 {% block coltype %}flex{% endblock %}
 
+{% block search %}{% if cl %}{% search_form cl %}{% endif %}{% endblock %}
+
+{% block messages %}
+  {{ block.super }}
+  {% if cl.formset.errors %}
+    <div class="alert alert-error{% if cl.formset.non_form_errors %} alert-block{% endif %}" data-alert="alert"><a class="close" href="#">x</a>
+      {% blocktrans count cl.formset.errors|length as counter %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}
+      {{ cl.formset.non_form_errors }}
+    </div>
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+{% comment %}
+In the standard django admin, the `object-tools` block is inside #content-main,
+but since this isn't part of the grid, it goes outside in *pops*.
+{% endcomment %}
 {% block object-tools %}
   {% if action_form or has_add_permission or cl %}
     <div class="subnav">
@@ -95,18 +112,6 @@ $(function() {
   {% endif %}
 {% endblock %}
 
-{% block search %}{% if cl %}{% search_form cl %}{% endif %}{% endblock %}
-
-{% block messages %}
-  {{ block.super }}
-  {% if cl.formset.errors %}
-    <div class="alert alert-error{% if cl.formset.non_form_errors %} alert-block{% endif %}" data-alert="alert"><a class="close" href="#">x</a>
-      {% blocktrans count cl.formset.errors|length as counter %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}
-      {{ cl.formset.non_form_errors }}
-    </div>
-  {% endif %}
-{% endblock %}
-{% block content %}
   <div id="content-main" class="row-fluid">
 
     <div class="span1{% if cl.has_filters %}0{% else %}2{% endif %}" id="changelist">

--- a/pops/templates/admin/submit_line.html
+++ b/pops/templates/admin/submit_line.html
@@ -11,19 +11,7 @@
   <div class="actions pull-right">
     <ul>
       <li class="action-item">
-        <div id="actions-right-alt" class="btn-group pull-left">
-          <a href="history/" class="btn">
-            <i class="icon-time"></i>
-            {% trans "History" %}
-          </a>
-
-          {% if has_absolute_url %}
-            <a href="../../../r/{{ content_type_id }}/{{ object_id }}/" class="btn">
-              <i class="icon-share-alt"></i>
-              {% trans "View on site" %}
-            </a>
-          {% endif %}
-        </div>
+        <div id="actions-right-alt" class="btn-group pull-left"></div>
       </li>
 
       <li class="action-item">
@@ -54,3 +42,31 @@
 
   <div style="clear:both;"></div>
 </div>
+
+{% comment %}
+Shiv to take object actions and move them to a prettier place.
+{% endcomment %}
+<script>
+  (function($){
+    // Try to use efficient selectors since this JS isn't deferred.
+    var $objectTools = $('#content-main > ul.object-tools'),
+        $container = $('#actions-right-alt'),
+        // Icons to attach to special buttons. Keep the trailing white space.
+        icons = {
+          historylink: '<i class="icon-time"></i> ',
+          viewsitelink: '<i class="icon-share-alt"></i> '
+        };
+
+    if (!$objectTools.length) { return; }
+
+    $objectTools.hide().find('a').each(function(){
+      var $el = $(this).clone(),
+          icon = icons[$el.attr('class')];
+      if (icon) {
+        $el.prepend(icon);
+      }
+      $el.addClass('btn').appendTo($container);
+    })
+
+  })(window.django.jQuery);
+</script>


### PR DESCRIPTION
NOT READY TO MERGE
- [ ] Javascript needs refactoring so it's not inline.

Fixes issue where pops throws away any object tools specified in the change_form.html template. It's not pretty... because the actions are rendered in a django include tag, to make the markup jump from the template into the include tag I used JavaScript.
