### PR TITLE
Fix missing select across logic in change_list

### DIFF
--- a/pops/templates/admin/change_list.html
+++ b/pops/templates/admin/change_list.html
@@ -120,12 +120,12 @@ TODO FIXME :This action block is hacked in.
 django's actions.js requires A tags inside questions
 {% endcomment %}
 <div class="actions btn-group">
-  <span class="action-counter btn">0 selected</span>
-  <span class="all btn hide">All selected</span>
-  <span class="question btn hide">
+  <span class="action-counter btn btn-mini">0 selected</span>
+  <span class="all btn btn-mini hide">All selected</span>
+  <span class="question btn btn-mini hide">
     <a title="Click here to select the objects across all pages" href="javascript:void(0);"><i class="icon-asterisk"></i> Select all</a>
   </span>
-  <span class="clear btn hide" style="clear:none;">{# we have to use the `clear` class due to a bug in django. #}
+  <span class="clear btn btn-mini hide" style="clear:none;">{# we have to use the `clear` class due to a bug in django. #}
     <a href="javascript:void(0);"><i class="icon-trash"></i> Clear selection</a>
   </span>
 </div>

--- a/pops/templates/admin/change_list.html
+++ b/pops/templates/admin/change_list.html
@@ -41,10 +41,12 @@ $(function() {
           // counterContainer: '',  // default: "span.action-counter"
           // allContainer: '',  // default: "div.actions span.all"
           acrossInput: "#id_select_across",  // default: "div.actions input.select-across"
-          // acrossQuestions: '', // default: "div.actions span.question"
-          // acrossClears: '',  // default: "div.actions span.clear"
           // allToggle: '',  // default:  "#action-toggle"
           selectedClass: "active"  // default: "selected"
+
+          // DUE TO A BUG IN DJANGO, WE HAVE TO USE THESE DEFAULTs:
+          // acrossQuestions: '', // default: "div.actions span.question"
+          // acrossClears: '',  // default: "div.actions span.clear"
         });
     });
 })(django.jQuery);
@@ -115,14 +117,17 @@ $(function() {
       {% block date_hierarchy %}{% date_hierarchy cl %}{% endblock %}
 {% comment %}
 TODO FIXME :This action block is hacked in.
+django's actions.js requires A tags inside questions
 {% endcomment %}
-<div class="actions">
-  <span class="action-counter" style="display: inline;">0 selected</span>
-  <span class="all hide">All selected</span>
-  <span class="question hide">
-      <a title="Click here to select the objects across all pages" href="javascript:;">Select all</a>
+<div class="actions btn-group">
+  <span class="action-counter btn">0 selected</span>
+  <span class="all btn hide">All selected</span>
+  <span class="question btn hide">
+    <a title="Click here to select the objects across all pages" href="javascript:void(0);"><i class="icon-asterisk"></i> Select all</a>
   </span>
-  <span class="clear hide"><a href="javascript:;">Clear selection</a></span>
+  <span class="clear btn hide" style="clear:none;">{# we have to use the `clear` class due to a bug in django. #}
+    <a href="javascript:void(0);"><i class="icon-trash"></i> Clear selection</a>
+  </span>
 </div>
       <form id="changelist-form" action="" method="post"{% if cl.formset.is_multipart %} enctype="multipart/form-data"{% endif %}>{% csrf_token %}
       {% if cl.formset %}

--- a/pops/templates/admin/change_list.html
+++ b/pops/templates/admin/change_list.html
@@ -95,6 +95,22 @@ $(function() {
           </div>
         {% endblock %}
       </div>
+{% comment %}
+TODO FIXME :This action block is hacked in.
+django's actions.js requires A tags inside questions.
+TODO fix indent level after next release. Left unintented on purpose to help
+help debug merge conflicts.
+{% endcomment %}
+<div class="actions btn-group">
+  <span class="action-counter btn btn-mini">0 selected</span>
+  <span class="all btn btn-mini hide">All selected</span>
+  <span class="question btn btn-mini hide">
+    <a title="Click here to select the objects across all pages" href="javascript:void(0);"><i class="icon-asterisk"></i> Select all</a>
+  </span>
+  <span class="clear btn btn-mini hide" style="clear:none;">{# we have to use the `clear` class due to a bug in django. #}
+    <a href="javascript:void(0);"><i class="icon-trash"></i> Clear selection</a>
+  </span>
+</div>
     </div>
   {% endif %}
 {% endblock %}
@@ -115,20 +131,6 @@ $(function() {
 
     <div class="span1{% if cl.has_filters %}0{% else %}2{% endif %}" id="changelist">
       {% block date_hierarchy %}{% date_hierarchy cl %}{% endblock %}
-{% comment %}
-TODO FIXME :This action block is hacked in.
-django's actions.js requires A tags inside questions
-{% endcomment %}
-<div class="actions btn-group">
-  <span class="action-counter btn btn-mini">0 selected</span>
-  <span class="all btn btn-mini hide">All selected</span>
-  <span class="question btn btn-mini hide">
-    <a title="Click here to select the objects across all pages" href="javascript:void(0);"><i class="icon-asterisk"></i> Select all</a>
-  </span>
-  <span class="clear btn btn-mini hide" style="clear:none;">{# we have to use the `clear` class due to a bug in django. #}
-    <a href="javascript:void(0);"><i class="icon-trash"></i> Clear selection</a>
-  </span>
-</div>
       <form id="changelist-form" action="" method="post"{% if cl.formset.is_multipart %} enctype="multipart/form-data"{% endif %}>{% csrf_token %}
       {% if cl.formset %}
         <div>{{ cl.formset.management_form }}</div>

--- a/pops/templates/admin/change_list.html
+++ b/pops/templates/admin/change_list.html
@@ -37,12 +37,14 @@ $(function() {
 (function($) {
     $(document).ready(function($) {
         $("tr input.action-select").actions({
-          actionContainer: 'div.actions',
-          counterContainer: '.selection_info, .selection-info span.action-counter',
-          allContainer: '.selection-info, .selection-info span.all',
-          acrossQuestions: 'span.question',
-          acrossClears: 'span.clear',
-          acrossInput: "div.changelist-actions input.select-across"
+          // actionContainer: '',  // default: "div.actions"
+          // counterContainer: '',  // default: "span.action-counter"
+          // allContainer: '',  // default: "div.actions span.all"
+          acrossInput: "#id_select_across",  // default: "div.actions input.select-across"
+          // acrossQuestions: '', // default: "div.actions span.question"
+          // acrossClears: '',  // default: "div.actions span.clear"
+          // allToggle: '',  // default:  "#action-toggle"
+          selectedClass: "active"  // default: "selected"
         });
     });
 })(django.jQuery);
@@ -111,7 +113,17 @@ $(function() {
 
     <div class="span1{% if cl.has_filters %}0{% else %}2{% endif %}" id="changelist">
       {% block date_hierarchy %}{% date_hierarchy cl %}{% endblock %}
-
+{% comment %}
+TODO FIXME :This action block is hacked in.
+{% endcomment %}
+<div class="actions">
+  <span class="action-counter" style="display: inline;">0 selected</span>
+  <span class="all hide">All selected</span>
+  <span class="question hide">
+      <a title="Click here to select the objects across all pages" href="javascript:;">Select all</a>
+  </span>
+  <span class="clear hide"><a href="javascript:;">Clear selection</a></span>
+</div>
       <form id="changelist-form" action="" method="post"{% if cl.formset.is_multipart %} enctype="multipart/form-data"{% endif %}>{% csrf_token %}
       {% if cl.formset %}
         <div>{{ cl.formset.management_form }}</div>


### PR DESCRIPTION
In the vanilla django admin, there's a blob that shows how many items you've selected, and exposes a button for doing a .all() on the queryset. This is currently missing in pops.
- [x] Needs design

![new old buttons](https://f.cloud.github.com/assets/189908/332180/37b49066-9c1a-11e2-8fa3-09335363ec17.jpg)
