### PR TITLE
Fix actions/input buttons in toolbar weren't clickable

### DIFF
--- a/pops/templates/admin/change_list.html
+++ b/pops/templates/admin/change_list.html
@@ -101,7 +101,7 @@ django's actions.js requires A tags inside questions.
 TODO fix indent level after next release. Left unintented on purpose to help
 help debug merge conflicts.
 {% endcomment %}
-<div class="actions btn-group">
+<div class="actions btn-group pull-left">
   <span class="action-counter btn btn-mini">0 selected</span>
   <span class="all btn btn-mini hide">All selected</span>
   <span class="question btn btn-mini hide">


### PR DESCRIPTION
Browsers are rendering the btn-group's box on top of floated inputs, so make the btn-group float too.

Tested locally in Chrome and Firefox.
### Testing instructions:
1. Browse locally to http://localhost:8000/admin/auth/user/ The search_filter input won't be clickable until after this patch is applied.
